### PR TITLE
fix: import path conflict in Python 3

### DIFF
--- a/easywatch/__init__.py
+++ b/easywatch/__init__.py
@@ -1,1 +1,1 @@
-from easywatch import watch
+from .easywatch import watch


### PR DESCRIPTION
In Python 3 relative imports have to be explicit, otherwise they are treated as global imports. This fix should work in Python 2.5+ and Python 3.x.
